### PR TITLE
Add verify step

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -39,3 +39,10 @@
   tags:
     - docker-machine-install-install
     - docker-machine-install-install-symlink
+
+- name: verify
+  shell: "{{ docker_machine_install_prefix }}/docker-machine --version"
+  register: verify_result
+- assert:
+    that:
+      - "docker_machine_version.replace('v', '', 1) in verify_result.stdout"


### PR DESCRIPTION
Verify successful download/installation by checking output of `docker-machine --version` matches the requested version. Should prevent it from completing successfully when some problem (e.g. a daft proxy returning a HTML error message) causes garbage to be downloaded instead of the correct binary.